### PR TITLE
Fix confusing "getaddrinfo" exception

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -221,7 +221,16 @@ class Lobby:
 
 
 if __name__ == '__main__':
-    ip = input("Enter Server IP: ")
+    ip, *port = input("Enter Server IP (ip or ip:port): ").split(':')
+    if len(port) == 0:
+        port = 7723
+    else:
+        try:
+            port = int(port[0])
+        except ValueError:
+            print('Invalid Port')
+            exit()
+    print(f'Using the IP {ip}:{port}')
     name = input("Enter Desired Name: ")
     lobby = Lobby()
-    lobby.main(name, ip, 7723)
+    lobby.main(name, ip, port)

--- a/client/client.py
+++ b/client/client.py
@@ -217,7 +217,10 @@ class Lobby:
 
                 if serialized: self.client.sendall(serialized.encode())
         except OSError as e:
-            print(f"Exception | {e}")
+            if e.errno == 11001 or e.errno == 10049:
+                print('Exception | Invalid IP')
+            else:
+                print(f'Exception | {e}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add a message when the client enters an Invalid IP, and let the client manually enter the server port, thus avoiding issues such as #3.